### PR TITLE
Specificity of /meta_knowledge_graph

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -87,7 +87,7 @@ paths:
         '200':
           description: >-
             Returns meta knowledge graph representation of this TRAPI web
-            service.
+            service.  
           content:
             application/json:
               schema:
@@ -678,19 +678,23 @@ components:
     MetaKnowledgeGraph:
       type: object
       description: >-
-        Knowledge-map representation of this TRAPI web service.
+        Knowledge-map representation of this TRAPI web service. The meta knowledge
+        graph is composed of the union of most specific categories and predicates for
+        each node and edge.
       properties:
         nodes:
           type: object
           description: >-
-            Collection of node categories provided by this TRAPI web service,
-            indexed by Biolink class CURIEs.
+            Collection of the most specific node categories provided by this TRAPI web service,
+            indexed by Biolink class CURIEs.   A node category is only exposed here if there is 
+            node for which that is the most specific category available.
           additionalProperties:
             $ref: '#/components/schemas/MetaNode'
         edges:
           type: array
           description: >-
-            List of edges/predicates provided by this TRAPI web service.
+            List of the most specific edges/predicates provided by this TRAPI web service. A predicate
+            is only exposed here if there is an edge for which the predicate is the most specific available.
           items:
             $ref: '#/components/schemas/MetaEdge'
           minItems: 1


### PR DESCRIPTION
Based on the 5/25 Architecture call, the prevailing opinion was that the meta knowledge graph endpoint should return a minimal specific set of catetgories/predicates and rely on ARAs to understand the inference rules and make sense of them.